### PR TITLE
docs: Aws Proton POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ DevOps is the practice of creating a cross-functional team between developers an
 
 - [POC Secret Management with Blackbox](https://github.com/UlisesGascon/POC-secret-management-with-blackbox) —  Store secrets securely in Git using strong encryption without compromising the developer experience.
 
+- [POC AWS Proton](https://github.com/guidesmiths/chapter-devops/tree/main/pocs/AwsProton) — Not only the conclusions after having tried this service, also a guide to configure a functional environment of it.
+
 
 ## Internet Of Things
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Best practices are procedures and techniques that have been proved to be effecti
 DevOps is the practice of creating a cross-functional team between developers and operations professionals to focus on efficiently delivering applications, services, and products to customers. DevOps teams strive to increase collaboration, communication, and coordination to produce results as quickly and efficiently as possible. This practice emphasizes the importance of working together to develop, deploy, and monitor applications quickly, reliably, and securely.
 
 - [POC Secret Management with Blackbox](https://github.com/UlisesGascon/POC-secret-management-with-blackbox) —  Store secrets securely in Git using strong encryption without compromising the developer experience.
-
 - [POC AWS Proton](https://github.com/guidesmiths/chapter-devops/tree/main/pocs/AwsProton) — Not only the conclusions after having tried this service, also a guide to configure a functional environment of it.
 
 


### PR DESCRIPTION
Added `AWS Proton` _POC_ references.

## Description
The <a href= "https://github.com/onebeyond/awesome-proof-of-concept#devops">DevOps</a> section now contains the references of the new POC from the DevOps chapter.
